### PR TITLE
Fix multiple instances of Firebase app

### DIFF
--- a/app/services/FCMService.py
+++ b/app/services/FCMService.py
@@ -12,18 +12,20 @@ class FCMService:
 
 	def __init__(self, base_url):
 		"""
-        Get credentials
-        """
+		Get credentials and initialize the app instance
+		"""
 		self.base_url = base_url
 		try:
 			cred = credentials.Certificate(self.FCM_CLIENT_SECRET_FILE)
 			self.app = firebase_admin.initialize_app(cred)
+		except ValueError:
+			raise ValueError('Firebase has been initialized multiple times')
 		except FileNotFoundError:
 			raise RuntimeError('Client secrets invalid')
 
 	def notify(self, app_event):
 		"""
-		Send notification to app users
+		Send notification to app users and remove app instance
 		"""
 		message = messaging.Message(
 			data={
@@ -35,3 +37,4 @@ class FCMService:
 		)
 
 		messaging.send(message)
+		firebase_admin.delete_app(self.app)


### PR DESCRIPTION
**Problem:**
Multiple instances of the Firebase app are being created, which is (no longer?) accepted by the Firebase python package.

**Error:**
![afbeelding](https://user-images.githubusercontent.com/13118481/94065774-d7ed0c80-fdeb-11ea-8991-db5d41e6d27f.png)
Full traceback is available if requested.

**Fix:**
The Firebase app instance is removed after sending the notification to Firebase, which should prevent creation of mutliple Firebaes app instances.

**Tested:** 
Has been tested locally with notification tests to a Firebase topic only available on my phone. (And accidentally once to all app users)